### PR TITLE
Fix direction of iteration for Reduce & ReduceRight types

### DIFF
--- a/src/Reduce/index.js
+++ b/src/Reduce/index.js
@@ -4,7 +4,7 @@ import type { Apply } from '..'
 
 declare function reduce<Fn, A, T, $>(Fn, A, T): $Call<
   Apply<
-    $Compose,
+    $ComposeReverse,
     $TupleMap<T, Fn>,
     $,
   >

--- a/src/Reduce/index.test.js
+++ b/src/Reduce/index.test.js
@@ -6,13 +6,13 @@ type MergeAll<T> = Reduce<<X, V>(V) => X => { ...$Exact<X>, ...$Exact<V> }, {}, 
 
 declare function mergeAll<A>(A): MergeAll<A>
 
-const x = mergeAll([{ a: 1 }, { b: 1 }, { c: 1 }])
+const x = mergeAll([{ a: 1 }, { b: 1 }, { c: 1 }, { a: 2 }])
 
-;(x: { a: 1, b: 1, c: 1 })
+;(x: { a: 2, b: 1, c: 1 })
 
 /**
  * $ExpectError
  *
  * the type of 'c' is incompatible with number
  */
-;(x: { a: 1, b: 1, c: '1' })
+;(x: { a: 2, b: 1, c: '1' })

--- a/src/ReduceRight/index.js
+++ b/src/ReduceRight/index.js
@@ -4,7 +4,7 @@ import type { Apply } from '..'
 
 declare function reduceRight<Fn, A, T, $>(Fn, A, T): $Call<
   Apply<
-    $ComposeReverse,
+    $Compose,
     $TupleMap<T, Fn>,
     $,
   >

--- a/src/ReduceRight/index.test.js
+++ b/src/ReduceRight/index.test.js
@@ -1,0 +1,18 @@
+/* @flow */
+
+import type { ReduceRight } from '..'
+
+type MergeAllRight<T> = ReduceRight<<X, V>(V) => X => { ...$Exact<X>, ...$Exact<V> }, {}, T>
+
+declare function mergeAllRight<A>(A): MergeAllRight<A>
+
+const x = mergeAllRight([{ a: 1 }, { b: 1 }, { c: 1 }, { a: 2 }])
+
+;(x: { a: 1, b: 1, c: 1 })
+
+/**
+ * $ExpectError
+ *
+ * the type of 'c' is incompatible with number
+ */
+;(x: { a: 1, b: 1, c: '1' })


### PR DESCRIPTION
When uses reduce, iteration should be left to right:
`[1, 2, 3].reduce((acc, item) => ..., null)` - the first item of iteration should be `1`, the second - `2`, the third - `3`.
When uses reduceRight, iteration should be right to left:
`[1, 2, 3].reduce((acc, item) => ..., null)` - the first item of iteration should be `3`, the second - `2`, the third - `1`.